### PR TITLE
feature (add create article  api and its test )

### DIFF
--- a/server/controllers/articlecontroller.js
+++ b/server/controllers/articlecontroller.js
@@ -1,0 +1,47 @@
+import dotenv from 'dotenv';
+// eslint-disable-next-line import/no-unresolved
+import ArticleModel from '../model/articleModel';
+
+import verifytoken from '../helpers/tokens';
+
+let authorid;
+const articleData = [
+
+];
+dotenv.config();
+
+class articleController {
+  // create article
+
+  static createArticle = (req, res) => {
+    const token = req.header('token');
+    const decode = verifytoken.verifyToken(token);
+
+    const articleId = articleData.length + 1;
+    authorid = decode.userEmail;
+    const createdOn = new Date();
+
+    const newArticle = new ArticleModel(
+      articleId,
+      authorid,
+      req.body.title,
+      req.body.article,
+      createdOn,
+    );
+
+    articleData.push(newArticle);
+    return res.status(201).json({
+      status: 201,
+      message: ' article successfully created',
+      data: {
+        articleId,
+        authorid,
+        title: newArticle.title,
+        article: newArticle.article,
+        createdOn,
+
+      },
+    });
+  }
+}
+export default { articleController, articleData };

--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@ import express from 'express';
 import bodyParse from 'body-parser';
 import dotenv from 'dotenv';
 import userRoute from './routes/userRoutes';
-
+import articleRoute from './routes/articleRoutes';
 
 dotenv.config();
 
@@ -11,7 +11,7 @@ app.use(bodyParse.json());
 
 
 app.use('/api/v1/auth', userRoute);
-
+app.use('/api/v1/articles', articleRoute);
 
 app.use('/', (req, res) => {
   res.status(404).send({

--- a/server/middleware/userauth.js
+++ b/server/middleware/userauth.js
@@ -1,0 +1,33 @@
+/* eslint-disable import/prefer-default-export */
+
+import user from '../controllers/usercontroller';
+import verifytoken from '../helpers/tokens';
+
+
+export const verifyUser = (req, res, next) => {
+  const token = req.header('token');
+  if (!token) {
+    return res.status(400).send({
+      status: 400,
+      error: 'Provide a Token',
+    });
+  }
+  try {
+    const decode = verifytoken.verifyToken(token);
+    const loadedUser = user.users.find(u => u.email === decode.userEmail);
+    if (!loadedUser) {
+      return res.status(401).send({
+        error: 'You are not a user', status: 401,
+
+      });
+    }
+
+
+    next();
+  } catch (error) {
+    return res.status(404).send({
+      status: 404,
+      error: 'invalid token',
+    });
+  }
+};

--- a/server/middleware/validCreateArticle.js
+++ b/server/middleware/validCreateArticle.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/prefer-default-export */
+import Joi from 'joi';
+// article validation
+export const validcreateArticle = (req, res, next) => {
+  const schema = {
+    title: Joi.string().required(),
+    article: Joi.string().required(),
+
+  };
+  const result = Joi.validate(req.body, schema);
+  if (result.error !== null) {
+    return res.status(400).send(
+      {
+        status: 400,
+        error: result.error.details[0].message,
+      },
+    );
+  }
+  next();
+};

--- a/server/model/articleModel.js
+++ b/server/model/articleModel.js
@@ -1,0 +1,15 @@
+import dotenv from 'dotenv';
+
+
+dotenv.config();
+
+class articleModel {
+  constructor(id, authorid, title, article, createdOn) {
+    this.id = id;
+    this.authorid = authorid;
+    this.title = title;
+    this.article = article;
+    this.createdon = createdOn;
+  }
+}
+export default articleModel;

--- a/server/model/articles.js
+++ b/server/model/articles.js
@@ -1,0 +1,21 @@
+import faker from 'faker';
+
+const articles = [
+  {
+    article: faker.lorem.paragraphs(),
+  },
+  {
+    title: ' ',
+    article: faker.lorem.paragraphs(),
+  },
+  {
+    title: '89977789',
+    article: faker.lorem.paragraphs(),
+  },
+  {
+    title: 'new in technology',
+    article: 'Technology is running faster',
+  },
+];
+
+export default articles;

--- a/server/routes/articleRoutes.js
+++ b/server/routes/articleRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { verifyUser } from '../middleware/userauth';
+import articleController from '../controllers/articlecontroller';
+import { validcreateArticle } from '../middleware/validCreateArticle';
+
+const router = express.Router();
+router.post('/', validcreateArticle, verifyUser, articleController.articleController.createArticle);
+
+
+export default router;

--- a/server/test/yArticleTest.js
+++ b/server/test/yArticleTest.js
@@ -1,0 +1,105 @@
+import chai from 'chai';
+
+import chaiHttp from 'chai-http';
+
+import app from '../index';
+
+
+import users from '../model/user';
+import articles from '../model/articles';
+import generateToken from '../helpers/tokens';
+
+const { expect } = chai;
+
+chai.use(chaiHttp);
+
+// ############ ARTICLE TESTS ############
+
+// Create a true token for testing
+const token = generateToken.generateToken(1, users[0].email);
+// Create a token with invalid user
+const notoken = ' ';
+const notusertoken = generateToken.generateToken(1, 'mmmnnnndj@gamil.com');
+const invalidtoken = 'ydhdhdijdhndhdgdgd';
+// creating an article with title missing
+
+describe('POST api/v1/articles title is missing', () => {
+  it('should return title is required', (done) => {
+    chai.request(app)
+      .post('/api/v1/articles')
+      .set('token', token)
+      .send(articles[0])
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        expect(res.body.error).to.equal('"title" is required');
+        done();
+      });
+  });
+});
+
+describe('POST api/v1/articles creating an article', () => {
+  it('should return an article is created successfully', (done) => {
+    chai.request(app)
+      .post('/api/v1/articles')
+      .set('Accept', 'application/json')
+      .send(articles[3])
+      .set('token', token)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(201);
+        expect(res.body.status).to.equal(201);
+        expect(res.body.message).to.equal(' article successfully created');
+        done();
+      });
+  });
+});
+
+describe('POST api/v1/articles creating an article with no token', () => {
+  it('should return an article creation  failed', (done) => {
+    chai.request(app)
+      .post('/api/v1/articles')
+      .set('Accept', 'application/json')
+      .send(articles[3])
+      .set('token', notoken)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal(400);
+        done();
+      });
+  });
+});
+
+describe('POST api/v1/articles creating an article with not a user email', () => {
+  it('should return an article creation  failed', (done) => {
+    chai.request(app)
+      .post('/api/v1/articles')
+      .set('Accept', 'application/json')
+      .send(articles[3])
+      .set('token', notusertoken)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(401);
+        expect(res.body.status).to.equal(401);
+        done();
+      });
+  });
+});
+
+describe('POST api/v1/articles creating an article with an invalid token', () => {
+  it('should return an article creation  failed', (done) => {
+    chai.request(app)
+      .post('/api/v1/articles')
+      .set('Accept', 'application/json')
+      .send(articles[3])
+      .set('token', invalidtoken)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(404);
+        expect(res.body.status).to.equal(404);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
1. Implement the following feed backs
   - Adjusts a create article  api
   - Adjust a  create article apis tests
  
#### Description of Task to be completed?

    - The user can start a server in cmd and start the server after
    - The user can sighin and get a token to arrow him to use POST /articles port for creating an article
    - The api is able to solve an error that a a user can make by sending him a  status code regarding to the error made 

#### How should this be manually tested?
    1. clone the the project
    2. Unzip it
    3. open cmd and run npm run dev-start to start the server for post man 
    4. or type npm run test for running the tests

#### Any background context you want to provide?
      N/A

#### What are the relevant pivotal tracker stories?
   [PT link] https://www.pivotaltracker.com/n/projects/2395939/stories/168790862)

#### Screenshots (if appropriate)
![article creation test](https://user-images.githubusercontent.com/53136152/65719203-8cebcc80-e0a5-11e9-980c-7f1479eb224d.jpg)
![article creation](https://user-images.githubusercontent.com/53136152/65719206-8f4e2680-e0a5-11e9-97ca-649f681784e2.jpg)


#### Questions:
     N/A