### PR TITLE
feature(add an edit article api and its test )

### DIFF
--- a/server/controllers/articlecontroller.js
+++ b/server/controllers/articlecontroller.js
@@ -43,5 +43,34 @@ class articleController {
       },
     });
   }
+
+  // edit article
+
+
+  static editArticle = (req, res) => {
+    const { articleId } = req.params;
+    const findarticle = articleData.find(u => u.id === parseInt(articleId, 10));
+
+    if (!findarticle) {
+      return res.status(404).send({
+        status: 404,
+        error: `No article available with id ${articleId}`,
+      });
+    }
+
+    findarticle.title = req.body.title;
+    findarticle.article = req.body.article;
+
+    return res.status(200).send({
+      status: 200,
+      message: 'article successfully edited',
+      data: {
+
+        articleId,
+        title: findarticle.title,
+        article: findarticle.article,
+      },
+    });
+  }
 }
 export default { articleController, articleData };

--- a/server/routes/articleRoutes.js
+++ b/server/routes/articleRoutes.js
@@ -5,6 +5,7 @@ import { validcreateArticle } from '../middleware/validCreateArticle';
 
 const router = express.Router();
 router.post('/', validcreateArticle, verifyUser, articleController.articleController.createArticle);
+router.patch('/:articleId', validcreateArticle, verifyUser, articleController.articleController.editArticle);
 
 
 export default router;

--- a/server/test/yArticleTest.js
+++ b/server/test/yArticleTest.js
@@ -103,3 +103,38 @@ describe('POST api/v1/articles creating an article with an invalid token', () =>
       });
   });
 });
+
+// edit article
+
+describe('PATCH api/v1/articles/:articleId article ', () => {
+  it('should return article successfully edited', (done) => {
+    chai.request(app)
+      .patch('/api/v1/articles/1')
+      .set('Accept', 'application/json')
+      .send(articles[3])
+      .set('token', token)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(200);
+        expect(res.body.status).to.equal(200);
+        expect(res.body.message).to.equal('article successfully edited');
+        done();
+      });
+  });
+});
+
+describe('PATCH api/v1/articles/:articleId article ', () => {
+  it('should return articleid not found', (done) => {
+    chai.request(app)
+      .patch('/api/v1/articles/3')
+      .set('Accept', 'application/json')
+      .send(articles[3])
+      .set('token', token)
+      .end((err, res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.status).to.equal(404);
+        expect(res.body.status).to.equal(404);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
1. Implement the following feed backs
   - Adjusts a edit article api
   - Adjust a  edit article tests
  
#### Description of Task to be completed?
    - The user can start a server in cmd and start the server after
    - The user can edit article using PATCH /articles/< articleId >port for editting an article
    - The api is able to solve an error that a a user can make by sending him a status code regarding to the error made 

#### How should this be manually tested?
    1. clone the the project
    2. Unzip it
    3. open cmd and run npm run dev-start to start the server for post man 
    4. or type npm run test for running the tests

#### Any background context you want to provide?
      N/A

#### What are the relevant pivotal tracker stories?
   [PT link] (https://www.pivotaltracker.com/n/projects/2395939/stories/168792472)
#### Screenshots (if appropriate)

![edit article successfully](https://user-images.githubusercontent.com/53136152/65721077-a55de600-e0a9-11e9-81fa-4eb4218e8bfd.jpg)
![edit article successfully test](https://user-images.githubusercontent.com/53136152/65721123-bd356a00-e0a9-11e9-83b8-6614a74f3b2b.jpg)


#### Questions:
     N/A